### PR TITLE
Fix an issue in the pick-up point picker

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Plugin Name: Sendy
 Plugin URI: https://app.sendy.nl/
 Description: A WooCommerce plugin that connects your site to the Sendy platform
-Version: 3.0.7
-Stable tag: 3.0.7
+Version: 3.0.8
+Stable tag: 3.0.8
 License: MIT
 Author: Sendy
 Author URI: https://sendy.nl/
@@ -11,7 +11,7 @@ Tested up to: 6.7.1
 Requires PHP: 7.4
 Requires Plugins: woocommerce
 WC requires at least: 8.2
-WC tested up to: 9.4.3
+WC tested up to: 9.5.2
 
 Een plugin van Sendy voor WooCommerce waarmee je op eenvoudige wijze labels aan kunt maken voor zendingen.
 
@@ -60,6 +60,9 @@ Hierbij worden de adres- en contactgegevens van de je klanten en (optioneel) de 
 Hierop zijn onze [algemene voorwaarden](https://sendy.nl/algemene-voorwaarden/) en [privacy statement](https://sendy.nl/privacy-statement/) van toepassing.
 
 == Changelog ==
+
+= 3.0.8 =
+* Fix an issue where the country was not used when selecting a pick-up point
 
 = 3.0.7 =
 * Reduce calls to the API when migrating legacy data

--- a/resources/js/checkout.js
+++ b/resources/js/checkout.js
@@ -13,7 +13,11 @@
         }
 
         let data = {
-            country: $('#shipping_country').find(':selected').val() ?? $('#billing_country').find(':selected').val(),
+            country: $('#shipping_country').find(':selected').val()
+                ?? $('#billing_country').find(':selected').val()
+                ?? $('#shipping_country').val()
+                ?? $('#billing_country').val()
+                ?? 'NL',
             carriers: [$('#sendy-pick-up-point-button').data('carrier')],
             address: address,
         };

--- a/sendy.php
+++ b/sendy.php
@@ -4,7 +4,7 @@
  * Plugin Name: Sendy
  * Plugin URI: https://app.sendy.nl/
  * Description: A WooCommerce plugin that connects your site to the Sendy platform
- * Version: 3.0.7
+ * Version: 3.0.8
  * Author: Sendy
  * Author URI: https://sendy.nl/
  * License: MIT
@@ -15,7 +15,7 @@
  * Requires PHP: 7.4
  * Requires Plugins: woocommerce
  * WC requires at least: 8.2
- * WC tested up to: 9.4.3
+ * WC tested up to: 9.5.2
  *
  * @package Sendy
  */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -14,7 +14,7 @@ use WC_Shipping_Method;
 
 class Plugin
 {
-    public const VERSION = '3.0.7';
+    public const VERSION = '3.0.8';
 
     public const SETTINGS_ID = 'sendy';
 


### PR DESCRIPTION
If the country selection is disabled, the script still attempts to read the country from the dropdown. The script is modified to read the value from the hidden field and will fall back to 'NL' if no value can be found.