### PR TITLE
Use the order number for shipment references

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,7 @@ Hierop zijn onze [algemene voorwaarden](https://sendy.nl/algemene-voorwaarden/) 
 
 = 3.1.2 =
 * Fix an error when creating a shipment
+* Use the order number as reference when creating a shipment
 
 = 3.1.1 =
 * Fix an error message when synchronizing shipping methods

--- a/src/Modules/Orders/OrdersModule.php
+++ b/src/Modules/Orders/OrdersModule.php
@@ -109,7 +109,7 @@ abstract class OrdersModule
         $request = [
             'shop_id' => $shopId ?? get_option('sendy_default_shop') ?? $firstShopId,
             'amount' => 1,
-            'reference' => $order->get_id(),
+            'reference' => $order->get_order_number(),
             'order_date' => $order->get_date_created()->format(\DateTimeInterface::RFC3339),
             'options' => [],
             'shippingMethodId' => $shippingMethod ? $shippingMethod->get_instance_id() : null,


### PR DESCRIPTION
Previously, the order ID was used as the reference when creating shipments. This PR replaces it with the order number to ensure better clarity and consistency.