### PR TITLE
Update the order status if needed

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,7 @@ Hierop zijn onze [algemene voorwaarden](https://sendy.nl/algemene-voorwaarden/) 
 
 = 3.1.3 =
 * Add validation for pick-up points in the checkout
+* Update the order status when a shipment is created via smart rules
 
 = 3.1.2 =
 * Fix an error when creating a shipment

--- a/src/Modules/Orders/OrdersModule.php
+++ b/src/Modules/Orders/OrdersModule.php
@@ -133,6 +133,11 @@ abstract class OrdersModule
             $shipment = ApiClientFactory::buildConnectionUsingTokens()->shipment->createWithSmartRules($request);
 
             $order->update_meta_data('_sendy_shipment_id', $shipment['uuid']);
+
+            if (get_option('sendy_mark_order_as_completed') === 'after-shipment-created') {
+                $order->set_status('completed', __('Sendy: Shipment created', 'sendy'));
+            }
+
             $order->save();
         } catch (ApiException $exception) {
             $message = $this->parseException($exception, $order);


### PR DESCRIPTION
The order status was not updated if the shipment was created via smart rules. This PR makes sure the order status is updated.