### PR TITLE
Restore the field for free shipping

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Plugin Name: Sendy
 Plugin URI: https://app.sendy.nl/
 Description: A WooCommerce plugin that connects your site to the Sendy platform
-Version: 3.2.0
-Stable tag: 3.2.0
+Version: 3.2.1
+Stable tag: 3.2.1
 License: MIT
 Author: Sendy
 Author URI: https://sendy.nl/
@@ -60,6 +60,9 @@ Hierbij worden de adres- en contactgegevens van de je klanten en (optioneel) de 
 Hierop zijn onze [algemene voorwaarden](https://sendy.nl/algemene-voorwaarden/) en [privacy statement](https://sendy.nl/privacy-statement/) van toepassing.
 
 == Changelog ==
+
+= 3.2.1 =
+* Restore the field for free shipping for the pick-up point delivery shipping method
 
 = 3.2.0 =
 * Add a different shipping method

--- a/sendy.php
+++ b/sendy.php
@@ -4,7 +4,7 @@
  * Plugin Name: Sendy
  * Plugin URI: https://app.sendy.nl/
  * Description: A WooCommerce plugin that connects your site to the Sendy platform
- * Version: 3.2.0
+ * Version: 3.2.1
  * Author: Sendy
  * Author URI: https://sendy.nl/
  * License: MIT

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,7 +18,7 @@ use WC_Shipping_Method;
 
 class Plugin
 {
-    public const VERSION = '3.2.0';
+    public const VERSION = '3.2.1';
 
     public const SETTINGS_ID = 'sendy';
 

--- a/src/ShippingMethods/PickupPointDelivery.php
+++ b/src/ShippingMethods/PickupPointDelivery.php
@@ -6,7 +6,9 @@ use WC_Shipping_Flat_Rate;
 
 class PickupPointDelivery extends WC_Shipping_Flat_Rate
 {
-    use ShippingMethodTrait;
+    use ShippingMethodTrait {
+        ShippingMethodTrait::instance_form_fields as trait_instance_form_fields;
+    }
 
     public const ID = 'sendy_pickup_point';
 
@@ -37,6 +39,8 @@ class PickupPointDelivery extends WC_Shipping_Flat_Rate
      */
     public function instance_form_fields(array $form_fields): array
     {
+        $form_fields = $this->trait_instance_form_fields($form_fields);
+
         $form_fields['carrier'] = [
             'title' => __('Carrier', 'sendy'),
             'type' => 'select',


### PR DESCRIPTION
With version 3.2.0 the field for free shipping was removed by accident for the pick-up point delivery shipping method. This change restores the field.