### PR TITLE
Use get_rest_url to get the webhook URL

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,9 @@ Hierop zijn onze [algemene voorwaarden](https://sendy.nl/algemene-voorwaarden/) 
 
 == Changelog ==
 
+= Unreleased =
+* Fix an issue where the webhook was not using the correct URL
+
 = 3.2.2 =
 * Fix an issue where the order status was not updated correctly
 

--- a/src/Modules/Webhooks.php
+++ b/src/Modules/Webhooks.php
@@ -146,7 +146,7 @@ class Webhooks
     {
         try {
             $webhook = ApiClientFactory::buildConnectionUsingTokens()->webhook->create([
-                'url' => get_site_url(null, 'wp-json/sendy/v1/webhook', 'https'),
+                'url' => get_rest_url(null, 'sendy/v1/webhook', 'https'),
                 'events' => [
                     'shipment.generated',
                     'shipment.deleted',


### PR DESCRIPTION
This ensures that the correct URL is used in all configurations