### PR TITLE
Flush the cache when tokens are refreshed

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Plugin Name: Sendy
 Plugin URI: https://app.sendy.nl/
 Description: A WooCommerce plugin that connects your site to the Sendy platform
-Version: 3.2.5
-Stable tag: 3.2.5
+Version: 3.2.6
+Stable tag: 3.2.6
 License: MIT
 Author: Sendy
 Author URI: https://sendy.nl/
@@ -51,6 +51,9 @@ Hierbij worden de adres- en contactgegevens van de je klanten en (optioneel) de 
 Hierop zijn onze [algemene voorwaarden](https://sendy.nl/algemene-voorwaarden/) en [privacy statement](https://sendy.nl/privacy-statement/) van toepassing.
 
 == Changelog ==
+
+= 3.2.6 =
+* Flush the cache when tokens are refreshed
 
 = 3.2.5 =
 * Use the order number as reference when creating a shipment

--- a/sendy.php
+++ b/sendy.php
@@ -4,7 +4,7 @@
  * Plugin Name: Sendy
  * Plugin URI: https://app.sendy.nl/
  * Description: A WooCommerce plugin that connects your site to the Sendy platform
- * Version: 3.2.5
+ * Version: 3.2.6
  * Author: Sendy
  * Author URI: https://sendy.nl/
  * License: MIT

--- a/src/ApiClientFactory.php
+++ b/src/ApiClientFactory.php
@@ -17,9 +17,15 @@ class ApiClientFactory
             ->setOauthClient(true)
             ->setRedirectUrl(sendy_oauth_redirect_url())
             ->setTokenUpdateCallback(function (Connection $connection) {
-                update_option('sendy_access_token', $connection->getAccessToken());
-                update_option('sendy_refresh_token', $connection->getRefreshToken());
-                update_option('sendy_token_expires', $connection->getTokenExpires());
+                update_option('sendy_access_token', $connection->getAccessToken(), false);
+                update_option('sendy_refresh_token', $connection->getRefreshToken(), false);
+                update_option('sendy_token_expires', $connection->getTokenExpires(), false);
+
+                if (function_exists('wp_cache_set')) {
+                    wp_cache_set('sendy_access_token', $connection->getAccessToken(), 'options');
+                    wp_cache_set('sendy_refresh_token', $connection->getRefreshToken(), 'options');
+                    wp_cache_set('sendy_token_expires', $connection->getTokenExpires(), 'options');
+                }
             })
         ;
     }

--- a/src/Modules/Admin/Settings.php
+++ b/src/Modules/Admin/Settings.php
@@ -73,7 +73,7 @@ class Settings
                 // the access token option and restart the authentication process from the start. Only resetting the
                 // access token is sufficient as it will not generate multiple instances of the WooCommerce integration
                 // in the Sendy application
-                update_option('sendy_access_token', null);
+                update_option('sendy_access_token', null, false);
             }
         }
 
@@ -255,7 +255,7 @@ class Settings
     {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
         if (isset($_GET['sendy_logout'])) {
-            update_option('sendy_access_token', null);
+            update_option('sendy_access_token', null, false);
 
             wp_safe_redirect(admin_url('admin.php?page=sendy'));
         }

--- a/src/Modules/OAuth.php
+++ b/src/Modules/OAuth.php
@@ -24,7 +24,7 @@ class OAuth
     {
         if (get_option('sendy_client_id') == '') {
             update_option('sendy_client_id', wp_generate_uuid4());
-            update_option('sendy_client_secret', wp_generate_password(40));
+            update_option('sendy_client_secret', wp_generate_password(40), false);
             update_option('sendy_hostname', get_site_url());
         }
     }
@@ -50,11 +50,11 @@ class OAuth
 
         if (get_option('sendy_hostname') != get_site_url()) {
             update_option('sendy_client_id', wp_generate_uuid4());
-            update_option('sendy_client_secret', wp_generate_password(40));
+            update_option('sendy_client_secret', wp_generate_password(40), false);
             update_option('sendy_hostname', get_site_url());
 
-            update_option('sendy_refresh_token', null);
-            update_option('sendy_token_expires', null);
+            update_option('sendy_refresh_token', null, false);
+            update_option('sendy_token_expires', null, false);
         }
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,7 +18,7 @@ use WC_Shipping_Method;
 
 class Plugin
 {
-    public const VERSION = '3.2.5';
+    public const VERSION = '3.2.6';
 
     public const SETTINGS_ID = 'sendy';
 


### PR DESCRIPTION
When the tokens are refreshed, the cache is now flushed to make sure the next calls to the API use the new token. Besides the flushing of the cache, all the options regarding the tokens are no longer autoloaded. This prevents the token from being stored in the `alloptions` object cache.