### PR TITLE
Replace action-gh-release with GitHub CLI

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -46,8 +46,7 @@ jobs:
           SLUG: 'sendy'
 
       - name: Attach the zip file to the release
-        uses: softprops/action-gh-release@v2
+        run:
+          gh release upload "${{ github.ref_name }}" "${{ github.workspace }}/sendy.zip" --clobber
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: ${{ github.workspace }}/sendy.zip
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Use the built-in `gh` CLI to upload the release zip file instead of relying on a third-party action, to avoid Node deprecation warning.

Follows the same pattern as our PrestaShop module: https://github.com/sendynl/prestashop-module/blob/master/.github/workflows/build-release.yml