### PR TITLE
Verify readme.txt before releasing

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -12,6 +12,18 @@ jobs:
       - name: Checkout the source code
         uses: actions/checkout@v5
 
+      - name: Verify readme.txt matches release version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! grep -q "^Stable tag: $VERSION$" readme.txt; then
+            echo "::error::Stable tag in readme.txt does not match release version $VERSION"
+            exit 1
+          fi
+          if ! grep -q "^= $VERSION =$" readme.txt; then
+            echo "::error::No changelog entry found in readme.txt for version $VERSION"
+            exit 1
+          fi
+
       - name: Install Subversion
         run: |
           sudo apt update

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -19,17 +19,19 @@ then
   exit 1
 fi
 
+if ! grep -q "^= $new_version =$" readme.txt
+then
+  echo "Error: No changelog entry found in readme.txt for version $new_version."
+  echo "Add a '= $new_version =' section under '== Changelog ==' before bumping."
+  exit 1
+fi
+
 echo "Bumping version to: $new_version"
 
 perl -pi -e "s/^Version: .*/Version: $new_version/" readme.txt
 perl -pi -e "s/^Stable tag: .*/Stable tag: $new_version/" readme.txt
 perl -pi -e "s/^ \* Version: .*/ \* Version: $new_version/" sendy.php
 perl -pi -e "s/^    public const VERSION = .*/    public const VERSION = '$new_version';/" lib/Plugin.php
-
-if ! grep -q "^= $new_version =$" readme.txt
-then
-  echo "Remember to add a new changelog entry in the readme.txt for version $new_version."
-fi
 
 echo
 echo "You can now commit the changes and merge them into the main branch. Then, create a new release on GitHub:"

--- a/lib/Plugin.php
+++ b/lib/Plugin.php
@@ -18,7 +18,7 @@ use WC_Shipping_Method;
 
 class Plugin
 {
-    public const VERSION = '3.4.3';
+    public const VERSION = '3.4.5';
 
     public const SETTINGS_ID = 'sendy';
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Plugin Name: Sendy
 Plugin URI: https://app.sendy.nl/
 Description: A WooCommerce plugin that connects your site to the Sendy platform
-Version: 3.4.3
-Stable tag: 3.4.3
+Version: 3.4.5
+Stable tag: 3.4.5
 License: MIT
 Author: Sendy
 Author URI: https://sendy.nl/
@@ -51,6 +51,12 @@ Hierbij worden de adres- en contactgegevens van de je klanten en (optioneel) de 
 Hierop zijn onze [algemene voorwaarden](https://sendy.nl/algemene-voorwaarden/) en [privacy statement](https://sendy.nl/privacy-statement/) van toepassing.
 
 == Changelog ==
+
+= 3.4.5 =
+* Fix missing changelog entry for version 3.4.4
+
+= 3.4.4 =
+* Fix special characters in OAuth secret
 
 = 3.4.3 =
 * Fix CVE-2025-68564 - Protect the logout endpoint

--- a/sendy.php
+++ b/sendy.php
@@ -4,7 +4,7 @@
  * Plugin Name: Sendy
  * Plugin URI: https://app.sendy.nl/
  * Description: A WooCommerce plugin that connects your site to the Sendy platform
- * Version: 3.4.3
+ * Version: 3.4.5
  * Author: Sendy
  * Author URI: https://sendy.nl/
  * License: MIT


### PR DESCRIPTION
Version 3.4.4 was released without a changelog entry or matching stable tag in readme.txt, which prevented it from appearing on wordpress.org. This adds checks to both bump_version.sh (fail early before modifying files) and the publish workflow (verify stable tag and changelog entry match the release version), and bumps to 3.4.5 with the missing 3.4.4 changelog entry.